### PR TITLE
Bump for Node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,5 +11,5 @@ outputs:
   name: 
     description: 'Issue type name'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Node 12 is now deprecated. Actions need to use node 16